### PR TITLE
Do not try to save virtual fields to db.

### DIFF
--- a/spec/allow_virtual_spec.cr
+++ b/spec/allow_virtual_spec.cr
@@ -58,6 +58,13 @@ describe "allow_virtual in forms" do
     form.setup_required_database_fields
     form.valid?.should be_false
   end
+
+  it "can still save to the database" do
+    params = {"password_confirmation" => "password", "terms_of_service" => "1"}
+    form = form(params)
+    form.setup_required_database_fields
+    form.save.should eq true
+  end
 end
 
 private def form(attrs = {} of String => String)

--- a/src/lucky_record/form.cr
+++ b/src/lucky_record/form.cr
@@ -151,7 +151,7 @@ abstract class LuckyRecord::Form(T)
 
   def changes
     _changes = {} of Symbol => String?
-    fields.each do |field|
+    database_fields.each do |field|
       if field.changed?
         _changes[field.name] = field.value.to_s
       end


### PR DESCRIPTION
First of all: I am super excited about lucky. Thanks for sharing!

Following the guide for adding virtual fields to forms, I encountered a small bug: When creating records lucky tried to save the virtual fields as well as the actual database fields.

This PR includes a very tiny fix that worked for me. Of course, I cannot be 100% sure that this does not have any side-effects I did not consider.

Also, the added test might be a bit clumsy. Let me know if there is anything I can improve.