### PR TITLE
Raise RecordNotFound for Queryable#first

### DIFF
--- a/spec/query_spec.cr
+++ b/spec/query_spec.cr
@@ -20,6 +20,12 @@ describe LuckyRecord::Query do
       insert_a_user
       UserQuery.new.first.name.should eq "Paul"
     end
+
+    it "raises RecordNotFound if no record is found" do
+      expect_raises(LuckyRecord::RecordNotFoundError, "") do
+        UserQuery.new.first
+      end
+    end
   end
 
   describe "#find" do

--- a/spec/query_spec.cr
+++ b/spec/query_spec.cr
@@ -22,7 +22,7 @@ describe LuckyRecord::Query do
     end
 
     it "raises RecordNotFound if no record is found" do
-      expect_raises(LuckyRecord::RecordNotFoundError, "") do
+      expect_raises(LuckyRecord::RecordNotFoundError) do
         UserQuery.new.first
       end
     end
@@ -37,13 +37,13 @@ describe LuckyRecord::Query do
     end
 
     it "raises RecordNotFound if no record is found with the given id (Int32)" do
-      expect_raises(LuckyRecord::RecordNotFoundError, "") do
+      expect_raises(LuckyRecord::RecordNotFoundError) do
         UserQuery.new.find(1)
       end
     end
 
     it "raises RecordNotFound if no record is found with the given id (String)" do
-      expect_raises(LuckyRecord::RecordNotFoundError, "") do
+      expect_raises(LuckyRecord::RecordNotFoundError) do
         UserQuery.new.find("1")
       end
     end

--- a/src/lucky_record/errors.cr
+++ b/src/lucky_record/errors.cr
@@ -5,7 +5,7 @@ module LuckyRecord
   class LuckyRecordError < Exception
   end
 
-  # Raised when a record could not be find
+  # Raised when a record could not be found
   class RecordNotFoundError < LuckyRecordError
     def initialize(@model : Symbol, @id : String)
       super "Could not find #{model} with id of #{id}"

--- a/src/lucky_record/errors.cr
+++ b/src/lucky_record/errors.cr
@@ -1,5 +1,3 @@
-require "lucky_inflector"
-
 module LuckyRecord
   # = Lucky Record Errors
   #
@@ -7,17 +5,14 @@ module LuckyRecord
   class LuckyRecordError < Exception
   end
 
-  # Raised when Lucky Record cannot find a record by given id
+  # Raised when a record could not be find
   class RecordNotFoundError < LuckyRecordError
     def initialize(@model : Symbol, @id : String)
       super "Could not find #{model} with id of #{id}"
     end
-  end
 
-  # Raised when Lucky Record cannot find a record by a query_method like #first or #last
-  class RecordNotFoundError < LuckyRecordError
     def initialize(@model : Symbol, @id : Symbol)
-      super "Could not find #{id} #{LuckyInflector::Inflector.singularize(model)}"
+      super "Could not find #{@id} record in #{model}"
     end
   end
 

--- a/src/lucky_record/errors.cr
+++ b/src/lucky_record/errors.cr
@@ -1,3 +1,5 @@
+require "lucky_inflector"
+
 module LuckyRecord
   # = Lucky Record Errors
   #
@@ -9,6 +11,13 @@ module LuckyRecord
   class RecordNotFoundError < LuckyRecordError
     def initialize(@model : Symbol, @id : String)
       super "Could not find #{model} with id of #{id}"
+    end
+  end
+
+  # Raised when Lucky Record cannot find a record by a query_method like #first or #last
+  class RecordNotFoundError < LuckyRecordError
+    def initialize(@model : Symbol, @id : Symbol)
+      super "Could not find #{id} #{LuckyInflector::Inflector.singularize(model)}"
     end
   end
 

--- a/src/lucky_record/errors.cr
+++ b/src/lucky_record/errors.cr
@@ -7,12 +7,12 @@ module LuckyRecord
 
   # Raised when a record could not be found
   class RecordNotFoundError < LuckyRecordError
-    def initialize(@model : Symbol, @id : String)
+    def initialize(model : Symbol, id : String)
       super "Could not find #{model} with id of #{id}"
     end
 
-    def initialize(@model : Symbol, @id : Symbol)
-      super "Could not find #{@id} record in #{model}"
+    def initialize(model : Symbol, query : Symbol)
+      super "Could not find #{query} record in #{model}"
     end
   end
 

--- a/src/lucky_record/queryable.cr
+++ b/src/lucky_record/queryable.cr
@@ -42,6 +42,8 @@ module LuckyRecord::Queryable(T)
   def first
     query.limit(1)
     exec_query.first
+  rescue IndexError
+    raise RecordNotFoundError.new(model: @@table_name, id: :first)
   end
 
   def count : Int64

--- a/src/lucky_record/queryable.cr
+++ b/src/lucky_record/queryable.cr
@@ -41,9 +41,7 @@ module LuckyRecord::Queryable(T)
 
   def first
     query.limit(1)
-    exec_query.first
-  rescue IndexError
-    raise RecordNotFoundError.new(model: @@table_name, id: :first)
+    exec_query.first? || raise RecordNotFoundError.new(model: @@table_name, id: :first)
   end
 
   def count : Int64

--- a/src/lucky_record/queryable.cr
+++ b/src/lucky_record/queryable.cr
@@ -41,7 +41,7 @@ module LuckyRecord::Queryable(T)
 
   def first
     query.limit(1)
-    exec_query.first? || raise RecordNotFoundError.new(model: @@table_name, id: :first)
+    exec_query.first? || raise RecordNotFoundError.new(model: @@table_name, query: :first)
   end
 
   def count : Int64


### PR DESCRIPTION
For #143.

There is no `#last` method, should I make an issue and add it?

I had to add an overload to `RecordNotFound` to handle generating an error message for query methods like `first`, but the attribute is still called `id` which may be misleading. Is this okay, or is there a better way to handle it?