### PR TITLE
Add first? and last? query methods that use existing implementation

### DIFF
--- a/spec/query_spec.cr
+++ b/spec/query_spec.cr
@@ -30,6 +30,21 @@ describe LuckyRecord::Query do
     end
   end
 
+  describe "#first?" do
+    it "gets the first row from the database" do
+      UserBox.new.name("First").save
+      UserBox.new.name("Last").save
+
+      user = UserQuery.new.first?
+      user.should_not be_nil
+      user && user.name.should eq "First"
+    end
+
+    it "returns nil if no record found" do
+      UserQuery.new.first?.should be_nil
+    end
+  end
+
   describe "#last" do
     it "gets the last row from the database" do
       UserBox.new.name("First").save
@@ -50,6 +65,21 @@ describe LuckyRecord::Query do
       expect_raises(LuckyRecord::RecordNotFoundError) do
         UserQuery.new.last
       end
+    end
+  end
+
+  describe "#last?" do
+    it "gets the last row from the database" do
+      UserBox.new.name("First").save
+      UserBox.new.name("Last").save
+
+      last = UserQuery.new.last?
+      last.should_not be_nil
+      last && last.name.should eq "Last"
+    end
+
+    it "returns nil if last record is not found" do
+      UserQuery.new.last?.should be_nil
     end
   end
 

--- a/spec/query_spec.cr
+++ b/spec/query_spec.cr
@@ -37,7 +37,7 @@ describe LuckyRecord::Query do
 
       user = UserQuery.new.first?
       user.should_not be_nil
-      user && user.name.should eq "First"
+      user.not_nil!.name.should eq "First"
     end
 
     it "returns nil if no record found" do

--- a/src/lucky_record/queryable.cr
+++ b/src/lucky_record/queryable.cr
@@ -45,26 +45,22 @@ module LuckyRecord::Queryable(T)
     id(id).limit(1).first? || raise RecordNotFoundError.new(model: @@table_name, id: id.to_s)
   end
 
-  def first
-    query.limit(1)
-    exec_query.first? || raise RecordNotFoundError.new(model: @@table_name, query: :first)
-  end
-
   def first?
-    first
-  rescue RecordNotFoundError
-    nil
+    query.limit(1)
+    exec_query.first?
   end
 
-  def last
-    ordered_query.reverse_order.limit(1)
-    exec_query.first? || raise RecordNotFoundError.new(model: @@table_name, query: :last)
+  def first
+    first? || raise RecordNotFoundError.new(model: @@table_name, query: :first)
   end
 
   def last?
-    last
-  rescue RecordNotFoundError
-    nil
+    ordered_query.reverse_order.limit(1)
+    exec_query.first?
+  end
+
+  def last
+    last? || raise RecordNotFoundError.new(model: @@table_name, query: :last)
   end
 
   def count : Int64

--- a/src/lucky_record/queryable.cr
+++ b/src/lucky_record/queryable.cr
@@ -50,6 +50,12 @@ module LuckyRecord::Queryable(T)
     exec_query.first? || raise RecordNotFoundError.new(model: @@table_name, query: :first)
   end
 
+  def first?
+    first
+  rescue RecordNotFoundError
+    nil
+  end
+
   def last
     ordered_query.reverse_order.limit(1)
     exec_query.first? || raise RecordNotFoundError.new(model: @@table_name, query: :last)

--- a/src/lucky_record/queryable.cr
+++ b/src/lucky_record/queryable.cr
@@ -55,6 +55,12 @@ module LuckyRecord::Queryable(T)
     exec_query.first? || raise RecordNotFoundError.new(model: @@table_name, query: :last)
   end
 
+  def last?
+    last
+  rescue RecordNotFoundError
+    nil
+  end
+
   def count : Int64
     query.count
     exec_scalar.as(Int64)


### PR DESCRIPTION
Closes #152 

I used the existing `first?` and `last?` methods and rescued `RecordNotFoundError` to avoid duplication.