### PR TITLE
Rename 'get' -> 'get?' and 'get!' -> 'get'.

### DIFF
--- a/src/lucky_record/paramable.cr
+++ b/src/lucky_record/paramable.cr
@@ -1,6 +1,6 @@
 module LuckyRecord::Paramable
   abstract def nested(key) : Hash(String, String)
   abstract def nested!(key) : Hash(String, String)
+  abstract def get?(key)
   abstract def get(key)
-  abstract def get!(key)
 end

--- a/src/lucky_record/params.cr
+++ b/src/lucky_record/params.cr
@@ -14,11 +14,11 @@ class LuckyRecord::Params
     @hash
   end
 
-  def get(key)
+  def get?(key)
     @hash[key]?
   end
 
-  def get!(key)
+  def get(key)
     @hash[key]
   end
 end


### PR DESCRIPTION
Needed for https://github.com/luckyframework/lucky/issues/342. Closes #187. This is more in line with crystal conventions.
Funny enough this wasn't used in any spec or other code 🤷‍♂️ 