### PR TITLE
Add support for Int64 and Float64 column types

### DIFF
--- a/db/migrations/20170127143149_create_users.cr
+++ b/db/migrations/20170127143149_create_users.cr
@@ -1,21 +1,14 @@
 class CreateUsers::V20170127143149 < LuckyMigrator::Migration::V1
   def migrate
-    execute <<-SQL
-      CREATE TABLE users (
-        id serial PRIMARY KEY,
-        name text NOT NULL,
-        created_at timestamp NOT NULL,
-        updated_at timestamp NOT NULL,
-        age int NOT NULL,
-        nickname text,
-        joined_at timestamp NOT NULL
-      )
-    SQL
+    create :users do
+      add name : String
+      add nickname : String?
+      add age : Int32
+      add joined_at : Time
+    end
   end
 
   def rollback
-    execute <<-SQL
-      DROP TABLE users
-    SQL
+    drop :users
   end
 end

--- a/db/migrations/20180113081408_create_companies.cr
+++ b/db/migrations/20180113081408_create_companies.cr
@@ -1,7 +1,8 @@
 class CreateCompanies::V20180113081408 < LuckyMigrator::Migration::V1
   def migrate
     create :companies do
-     add sales : Int64
+      add sales : Int64
+      add earnings : Float
     end
   end
 

--- a/db/migrations/20180113081408_create_companies.cr
+++ b/db/migrations/20180113081408_create_companies.cr
@@ -1,0 +1,11 @@
+class CreateCompanies::V20180113081408 < LuckyMigrator::Migration::V1
+  def migrate
+    create :companies do
+     add sales : Int64
+    end
+  end
+
+  def rollback
+    drop :companies
+  end
+end

--- a/spec/support/boxes/company_box.cr
+++ b/spec/support/boxes/company_box.cr
@@ -1,0 +1,5 @@
+class CompanyBox < BaseBox
+  def initialize
+    sales (Int32::MAX + 1000).to_i64
+  end
+end

--- a/spec/support/boxes/company_box.cr
+++ b/spec/support/boxes/company_box.cr
@@ -1,6 +1,6 @@
 class CompanyBox < BaseBox
   def initialize
-    sales (Int32::MAX + 1000).to_i64
+    sales Int64::MAX
     earnings 1.0
   end
 end

--- a/spec/support/boxes/company_box.cr
+++ b/spec/support/boxes/company_box.cr
@@ -1,5 +1,6 @@
 class CompanyBox < BaseBox
   def initialize
     sales (Int32::MAX + 1000).to_i64
+    earnings 1.0
   end
 end

--- a/spec/support/company.cr
+++ b/spec/support/company.cr
@@ -1,5 +1,6 @@
 class Company < LuckyRecord::Model
   table companies do
     column sales : Int64
+    column earnings : Float64
   end
 end

--- a/spec/support/company.cr
+++ b/spec/support/company.cr
@@ -1,0 +1,5 @@
+class Company < LuckyRecord::Model
+  table companies do
+    column sales : Int64
+  end
+end

--- a/spec/type_extension_spec.cr
+++ b/spec/type_extension_spec.cr
@@ -1,0 +1,36 @@
+require "./spec_helper.cr"
+
+class CompanyQuery < Company::BaseQuery
+end
+
+class CompanyForm < Company::BaseForm
+  allow :sales
+
+  def prepare
+    validate_required sales
+  end
+end
+
+describe "TypeExtensions" do
+  it "should work in boxes" do
+    CompanyBox.save
+    company = CompanyQuery.new.first
+    company.sales.should eq Int32::MAX + 1000
+
+    company2 = CompanyBox.new.sales(10_i64).save
+    company2.sales.should eq 10_i64
+  end
+
+  it "should build and save forms" do
+    form = CompanyForm.new({"sales" => "10"})
+    form.sales.value.should eq 10_i64
+    company = form.save!
+    company.sales.should eq 10_i64
+  end
+
+  it "should query" do
+    CompanyBox.new.sales(10_i64).save
+    company = CompanyQuery.new.sales(10).first
+    company.sales.should eq 10_i64
+  end
+end

--- a/spec/type_extension_spec.cr
+++ b/spec/type_extension_spec.cr
@@ -16,7 +16,7 @@ describe "TypeExtensions" do
   it "should work in boxes" do
     CompanyBox.save
     company = CompanyQuery.new.first
-    company.sales.should eq Int32::MAX + 1000
+    company.sales.should eq Int64::MAX
     company.earnings.should eq 1.0
 
     company2 = CompanyBox.new.sales(10_i64).earnings(2.0).save

--- a/spec/type_extension_spec.cr
+++ b/spec/type_extension_spec.cr
@@ -24,16 +24,18 @@ describe "TypeExtensions" do
     company2.earnings.should eq 2.0
   end
 
-  it "should build and save forms" do
-    form = CompanyForm.new({"sales" => "10", "earnings" => "10.0"})
+  it "should convert params and save forms" do
+    form = CompanyForm.new({"sales" => "10", "earnings" => "10"})
     form.sales.value.should eq 10_i64
     form.earnings.value.should eq 10.0
   end
 
-  it "should query" do
+  it "Int64 and Float64 should allow querying with Int32" do
     CompanyBox.new.sales(10_i64).earnings(1.0).save
-    company = CompanyQuery.new.sales(10).earnings(1.0).first
-    company.sales.should eq 10_i64
-    company.earnings.should eq 1.0
+    using_sales = CompanyQuery.new.sales(10).first
+    using_sales.sales.should eq 10_i64
+
+    using_earnings = CompanyQuery.new.earnings(1).first
+    using_earnings.earnings.should eq 1.0
   end
 end

--- a/spec/type_extension_spec.cr
+++ b/spec/type_extension_spec.cr
@@ -4,10 +4,11 @@ class CompanyQuery < Company::BaseQuery
 end
 
 class CompanyForm < Company::BaseForm
-  allow :sales
+  allow :sales, :earnings
 
   def prepare
     validate_required sales
+    validate_required earnings
   end
 end
 
@@ -16,21 +17,23 @@ describe "TypeExtensions" do
     CompanyBox.save
     company = CompanyQuery.new.first
     company.sales.should eq Int32::MAX + 1000
+    company.earnings.should eq 1.0
 
-    company2 = CompanyBox.new.sales(10_i64).save
+    company2 = CompanyBox.new.sales(10_i64).earnings(2.0).save
     company2.sales.should eq 10_i64
+    company2.earnings.should eq 2.0
   end
 
   it "should build and save forms" do
-    form = CompanyForm.new({"sales" => "10"})
+    form = CompanyForm.new({"sales" => "10", "earnings" => "10.0"})
     form.sales.value.should eq 10_i64
-    company = form.save!
-    company.sales.should eq 10_i64
+    form.earnings.value.should eq 10.0
   end
 
   it "should query" do
-    CompanyBox.new.sales(10_i64).save
-    company = CompanyQuery.new.sales(10).first
+    CompanyBox.new.sales(10_i64).earnings(1.0).save
+    company = CompanyQuery.new.sales(10).earnings(1.0).first
     company.sales.should eq 10_i64
+    company.earnings.should eq 1.0
   end
 end

--- a/src/lucky_record/blank_extensions.cr
+++ b/src/lucky_record/blank_extensions.cr
@@ -16,6 +16,12 @@ struct Int64
   end
 end
 
+struct Float64
+  def blank?
+    nil?
+  end
+end
+
 struct Nil
   def blank?
     nil?

--- a/src/lucky_record/blank_extensions.cr
+++ b/src/lucky_record/blank_extensions.cr
@@ -10,6 +10,12 @@ struct Int32
   end
 end
 
+struct Int64
+  def blank?
+    nil?
+  end
+end
+
 struct Nil
   def blank?
     nil?

--- a/src/lucky_record/charms/float64_extensions.cr
+++ b/src/lucky_record/charms/float64_extensions.cr
@@ -1,0 +1,39 @@
+struct Float64
+  module Lucky
+    alias ColumnType = Float64
+    include LuckyRecord::Type
+
+    def self.from_db!(value : Float64)
+      value
+    end
+
+    def self.from_db!(value : PG::Numeric)
+      value.to_f
+    end
+
+    def self.parse(value : Float64)
+      SuccessfulCast(Float64).new(value)
+    end
+
+    def self.parse(value : String)
+      SuccessfulCast(Float64).new value.to_f64
+    rescue ArgumentError
+      FailedCast.new
+    end
+
+    def self.parse(value : Int32)
+      SuccessfulCast(Float64).new value.to_f64
+    end
+
+    def self.parse(value : Int64)
+      SuccessfulCast(Float64).new value.to_f64
+    end
+
+    def self.to_db(value : Float64)
+      value.to_s
+    end
+
+    class Criteria(T, V) < LuckyRecord::Criteria(T, V)
+    end
+  end
+end

--- a/src/lucky_record/charms/int64_extensions.cr
+++ b/src/lucky_record/charms/int64_extensions.cr
@@ -1,0 +1,31 @@
+struct Int64
+  module Lucky
+    alias ColumnType = Int64
+    include LuckyRecord::Type
+
+    def self.from_db!(value : Int64)
+      value
+    end
+
+    def self.parse(value : Int64)
+      SuccessfulCast(Int64).new(value)
+    end
+
+    def self.parse(value : String)
+      SuccessfulCast(Int64).new value.to_i64
+    rescue ArgumentError
+      FailedCast.new
+    end
+
+    def self.parse(value : Int32)
+      SuccessfulCast(Int64).new value.to_i64
+    end
+
+    def self.to_db(value : Int64)
+      value.to_s
+    end
+
+    class Criteria(T, V) < LuckyRecord::Criteria(T, V)
+    end
+  end
+end

--- a/src/lucky_record/model.cr
+++ b/src/lucky_record/model.cr
@@ -58,6 +58,11 @@ class LuckyRecord::Model
     end
   end
 
+  # Setup [database mapping](http://crystal-lang.github.io/crystal-db/api/0.5.0/DB.html#mapping%28properties%2Cstrict%3Dtrue%29-macro) for the model's fields.
+  #
+  # NOTE: LuckyMigrator saves `Float` columns as numeric which need to be
+  # converted from [PG::Numeric](https://github.com/will/crystal-pg/blob/master/src/pg/numeric.cr) back to `Float64` using a `convertor`
+  # class.
   macro setup_db_mapping
     DB.mapping({
       {% for field in FIELDS %}

--- a/src/lucky_record/model.cr
+++ b/src/lucky_record/model.cr
@@ -67,7 +67,7 @@ class LuckyRecord::Model
     DB.mapping({
       {% for field in FIELDS %}
         {{field[:name]}}: {
-          {% if "#{field[:type]}" == "Float64" %}
+          {% if field[:type] == Float64.id %}
             type: PG::Numeric,
             convertor: Float64Convertor,
           {% else %}

--- a/src/lucky_record/model.cr
+++ b/src/lucky_record/model.cr
@@ -62,11 +62,22 @@ class LuckyRecord::Model
     DB.mapping({
       {% for field in FIELDS %}
         {{field[:name]}}: {
-          type: {{field[:type]}}::Lucky::ColumnType,
+          {% if "#{field[:type]}" == "Float64" %}
+            type: PG::Numeric,
+            convertor: Float64Convertor,
+          {% else %}
+            type: {{field[:type]}}::Lucky::ColumnType,
+          {% end %}
           nilable: {{field[:nilable]}},
         },
       {% end %}
     })
+  end
+
+  module Float64Converter
+    def self.from_rs(rs)
+      rs.read(PG::Numeric).to_f
+    end
   end
 
   macro setup_base_query_class(table_name)


### PR DESCRIPTION
I added support for both `Int64` and `Float64` because the process was similar.

Let me know if there's anything missing, I'd like to use this in a project right now. And once this is merged I can start working on using `Int64` for ids.