### PR TITLE
Replace static 'Tag' reference

### DIFF
--- a/src/lucky_record/associations.cr
+++ b/src/lucky_record/associations.cr
@@ -64,7 +64,7 @@ module LuckyRecord::Associations
               end
               .preload_{{ through.id }}
               .distinct
-            {{ assoc_name }} = {} of Int32 => Array(Tag)
+            {{ assoc_name }} = {} of Int32 => Array({{ model }})
             all_{{ assoc_name }}.each do |item|
               item.{{ through.id }}.each do |item_through|
                 {{ assoc_name }}[item_through.{{ foreign_key }}] ||= Array({{ model }}).new


### PR DESCRIPTION
Replaces the static reference to 'Tag' with the appropriate expanded AST Node. This fixes an undefined constant error when preloading associations.