### PR TITLE
gitignore now ignores "docs" instead of "doc"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-/doc/
+/docs/
 /lib/
 /bin/
 /.shards/


### PR DESCRIPTION
Crystal changed the default doc folder to "docs" https://github.com/crystal-lang/crystal/issues/4918