### PR TITLE
Ignore self when validating uniqueness.

### DIFF
--- a/spec/query_spec.cr
+++ b/spec/query_spec.cr
@@ -1,6 +1,6 @@
 require "./spec_helper"
 
-private class ChainedQuery < User::BaseQuery
+class ChainedQuery < User::BaseQuery
   def young
     age.lte(18)
   end

--- a/spec/validations_spec.cr
+++ b/spec/validations_spec.cr
@@ -134,7 +134,7 @@ describe LuckyRecord::Validations do
   end
 
   describe "validate_uniqueness_of" do
-    it "validates that a record is unique with a query or without one" do
+    it "validates that a new record is unique with a query or without one" do
       existing_user = UserBox.new.name("Sally").nickname("Sal").create
       form = UniquenessWithDatabaseBackedForm.new
       form.name.value = existing_user.name
@@ -144,6 +144,16 @@ describe LuckyRecord::Validations do
 
       form.name.errors.should contain "is already taken"
       form.nickname.errors.should contain "is already taken"
+    end
+
+    it "ignores the existing record on update" do
+      existing_user = UserBox.new.name("Sally").create
+      form = UniquenessWithDatabaseBackedForm.new(existing_user)
+      form.name.value = existing_user.name
+
+      form.prepare
+
+      form.name.errors.should_not contain "is already taken"
     end
   end
 

--- a/src/lucky_record/validations.cr
+++ b/src/lucky_record/validations.cr
@@ -81,7 +81,7 @@ module LuckyRecord::Validations
     private def build_validation_query(column_name, value) : T::BaseQuery
       query = T::BaseQuery.new.where(column_name, value)
       record.try(&.id).try do |id|
-        query = query.where("#{T::TABLE_NAME}.id != ?", id)
+        query = query.id.not(id)
       end
       query
     end

--- a/src/lucky_record/validations.cr
+++ b/src/lucky_record/validations.cr
@@ -79,7 +79,13 @@ module LuckyRecord::Validations
   # if because there is no T (model class).
   macro included
     private def build_validation_query(column_name, value) : T::BaseQuery
-      T::BaseQuery.new.where(column_name, value)
+      query = T::BaseQuery.new.where(column_name, value)
+      record.try do |r|
+        r.id.try do |id|
+          query = query.where("#{T::TABLE_NAME}.id != ?", id)
+        end
+      end
+      query
     end
   end
 end

--- a/src/lucky_record/validations.cr
+++ b/src/lucky_record/validations.cr
@@ -80,10 +80,8 @@ module LuckyRecord::Validations
   macro included
     private def build_validation_query(column_name, value) : T::BaseQuery
       query = T::BaseQuery.new.where(column_name, value)
-      record.try do |r|
-        r.id.try do |id|
-          query = query.where("#{T::TABLE_NAME}.id != ?", id)
-        end
+      record.try(&.id).try do |id|
+        query = query.where("#{T::TABLE_NAME}.id != ?", id)
       end
       query
     end


### PR DESCRIPTION
validates_uniqueness_of can be useful on update, in case the unique field's value is being updated. But if the value stays the same, the validation reported an error.

This is now fixed, as the current record is being ignored when searching for conflicting records in the database.

Of course, when supplying your own query, you are on your own :slightly_frowning_face: 

I dabbled with automatically injecting something in this case as well, but gave up after some time. I guess it is better to document this as a caveat than to tamper with the user supplied query.