### PR TITLE
Allow model fields named 'value'. Fixes #266

### DIFF
--- a/spec/form_spec.cr
+++ b/spec/form_spec.cr
@@ -25,6 +25,16 @@ private class LineItemForm < LineItem::BaseForm
   fillable :name
 end
 
+private class ValueColumnModel < LuckyRecord::Model
+  table :value_column_model do
+    column value : String
+  end
+end
+
+private class ValueColumnModelForm < ValueColumnModel::BaseForm
+  fillable value
+end
+
 describe "LuckyRecord::Form" do
   it "generates the correct form_name" do
     LimitedUserForm.new.form_name.should eq "limited_user"
@@ -342,6 +352,10 @@ describe "LuckyRecord::Form" do
         )
         LineItemQuery.new.id("a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11").select_count.should eq 1
       end
+    end
+
+    it "can handle a field named 'value'" do
+      ValueColumnModelForm.new({"value" => "value"}).value.value.should eq "value"
     end
   end
 

--- a/src/lucky_record/form.cr
+++ b/src/lucky_record/form.cr
@@ -114,8 +114,8 @@ abstract class LuckyRecord::Form(T)
         new_params.select(@@fillable_param_keys)
       end
 
-      def set_{{ field[:name] }}_from_param(value)
-        parse_result = {{ field[:type] }}::Lucky.parse(value)
+      def set_{{ field[:name] }}_from_param(_value)
+        parse_result = {{ field[:type] }}::Lucky.parse(_value)
         if parse_result.is_a? LuckyRecord::Type::SuccessfulCast
           {{ field[:name] }}.value = parse_result.value
         else


### PR DESCRIPTION
There is no reason this shouldn't work. Renaming the argument did the trick.