### PR TITLE
Pass Int32 Values to DB as integer

### DIFF
--- a/spec/criteria_spec.cr
+++ b/spec/criteria_spec.cr
@@ -11,54 +11,54 @@ end
 describe LuckyRecord::Criteria do
   describe "is" do
     it "uses =" do
-      age.is(30).to_sql.should eq ["SELECT #{QueryMe::COLUMNS} FROM users WHERE users.age = $1", "30"]
+      age.is(30).to_sql.should eq ["SELECT #{QueryMe::COLUMNS} FROM users WHERE users.age = $1", 30]
     end
   end
 
   describe "is_not" do
     it "uses !=" do
-      age.is_not(30).to_sql.should eq ["SELECT #{QueryMe::COLUMNS} FROM users WHERE users.age != $1", "30"]
+      age.is_not(30).to_sql.should eq ["SELECT #{QueryMe::COLUMNS} FROM users WHERE users.age != $1", 30]
     end
   end
 
   describe "gt" do
     it "uses >" do
-      age.gt("30").to_sql.should eq ["SELECT #{QueryMe::COLUMNS} FROM users WHERE users.age > $1", "30"]
+      age.gt("30").to_sql.should eq ["SELECT #{QueryMe::COLUMNS} FROM users WHERE users.age > $1", 30]
     end
   end
 
   describe "gte" do
     it "uses >=" do
-      age.gte("30").to_sql.should eq ["SELECT #{QueryMe::COLUMNS} FROM users WHERE users.age >= $1", "30"]
+      age.gte("30").to_sql.should eq ["SELECT #{QueryMe::COLUMNS} FROM users WHERE users.age >= $1", 30]
     end
   end
 
   describe "lt" do
     it "uses <" do
-      age.lt("30").to_sql.should eq ["SELECT #{QueryMe::COLUMNS} FROM users WHERE users.age < $1", "30"]
+      age.lt("30").to_sql.should eq ["SELECT #{QueryMe::COLUMNS} FROM users WHERE users.age < $1", 30]
     end
   end
 
   describe "lte" do
     it "uses <=" do
-      age.lte("30").to_sql.should eq ["SELECT #{QueryMe::COLUMNS} FROM users WHERE users.age <= $1", "30"]
+      age.lte("30").to_sql.should eq ["SELECT #{QueryMe::COLUMNS} FROM users WHERE users.age <= $1", 30]
     end
   end
 
   describe "not" do
     describe "without chained criteria" do
       it "negates to not equal" do
-        age.not("30").to_sql.should eq ["SELECT #{QueryMe::COLUMNS} FROM users WHERE users.age != $1", "30"]
+        age.not("30").to_sql.should eq ["SELECT #{QueryMe::COLUMNS} FROM users WHERE users.age != $1", 30]
       end
     end
 
     describe "with chained criteria" do
       it "negates the following criteria" do
-        age.not.gt("3").to_sql.should eq ["SELECT #{QueryMe::COLUMNS} FROM users WHERE users.age <= $1", "3"]
+        age.not.gt(3).to_sql.should eq ["SELECT #{QueryMe::COLUMNS} FROM users WHERE users.age <= $1", 3]
       end
 
       it "resets after having negated once" do
-        age.not.gt("3").age.is("20").to_sql.should eq ["SELECT #{QueryMe::COLUMNS} FROM users WHERE users.age <= $1 AND users.age = $2", "3", "20"]
+        age.not.gt(3).age.is(20).to_sql.should eq ["SELECT #{QueryMe::COLUMNS} FROM users WHERE users.age <= $1 AND users.age = $2", 3, 20]
       end
     end
   end

--- a/spec/model_spec.cr
+++ b/spec/model_spec.cr
@@ -97,19 +97,19 @@ describe LuckyRecord::Model do
   it "sets up simple methods for equality" do
     query = QueryMe::BaseQuery.new.email("foo@bar.com").age(30)
 
-    query.to_sql.should eq ["SELECT #{QueryMe::COLUMNS} FROM users WHERE users.email = $1 AND users.age = $2", "foo@bar.com", "30"]
+    query.to_sql.should eq ["SELECT #{QueryMe::COLUMNS} FROM users WHERE users.email = $1 AND users.age = $2", "foo@bar.com", 30]
   end
 
   it "sets up advanced criteria methods" do
     query = QueryMe::BaseQuery.new.email.upper.is("foo@bar.com").age.gt(30)
 
-    query.to_sql.should eq ["SELECT #{QueryMe::COLUMNS} FROM users WHERE UPPER(users.email) = $1 AND users.age > $2", "foo@bar.com", "30"]
+    query.to_sql.should eq ["SELECT #{QueryMe::COLUMNS} FROM users WHERE UPPER(users.email) = $1 AND users.age > $2", "foo@bar.com", 30]
   end
 
   it "parses values" do
     query = QueryMe::BaseQuery.new.email.upper.is(" Foo@bar.com").age.gt(30)
 
-    query.to_sql.should eq ["SELECT #{QueryMe::COLUMNS} FROM users WHERE UPPER(users.email) = $1 AND users.age > $2", "foo@bar.com", "30"]
+    query.to_sql.should eq ["SELECT #{QueryMe::COLUMNS} FROM users WHERE UPPER(users.email) = $1 AND users.age > $2", "foo@bar.com", 30]
   end
 
   it "lets you order by columns" do

--- a/spec/query_spec.cr
+++ b/spec/query_spec.cr
@@ -216,7 +216,7 @@ describe LuckyRecord::Query do
       query = UserQuery.new.where(:id, 1).query
 
       query.statement.should eq "SELECT #{User::COLUMNS} FROM users WHERE id = $1"
-      query.args.should eq ["1"]
+      query.args.should eq [1]
     end
 
     it "accepts raw sql with bindings and chains with itself" do

--- a/src/lucky_record/charms/int32_extensions.cr
+++ b/src/lucky_record/charms/int32_extensions.cr
@@ -18,7 +18,7 @@ struct Int32
     end
 
     def self.to_db(value : Int32)
-      value.to_s
+      value
     end
 
     class Criteria(T, V) < LuckyRecord::Criteria(T, V)

--- a/src/lucky_record/queryable.cr
+++ b/src/lucky_record/queryable.cr
@@ -52,8 +52,8 @@ module LuckyRecord::Queryable(T)
     self
   end
 
-  def where(column : Symbol, value)
-    query.where(LuckyRecord::Where::Equal.new(column, value.to_s))
+  def where(column, value)
+    query.where(LuckyRecord::Where::Equal.new(column, value))
     self
   end
 

--- a/src/lucky_record/where.cr
+++ b/src/lucky_record/where.cr
@@ -2,7 +2,7 @@ module LuckyRecord::Where
   abstract class SqlClause
     getter :column, :value
 
-    def initialize(@column : Symbol | String, @value : String | Int32 | Array(String) | Array(Int32))
+    def initialize(@column : Symbol | String, @value : String | Int32 | Nil | Array(String) | Array(Int32))
     end
 
     abstract def operator : String

--- a/src/lucky_record/where.cr
+++ b/src/lucky_record/where.cr
@@ -2,7 +2,7 @@ module LuckyRecord::Where
   abstract class SqlClause
     getter :column, :value
 
-    def initialize(@column : Symbol | String, @value : String | Array(String) | Array(Int32))
+    def initialize(@column : Symbol | String, @value : String | Int32 | Array(String) | Array(Int32))
     end
 
     abstract def operator : String


### PR DESCRIPTION
I used `hub` to get the old pull request and rebase it (awesome tool btw). There are a couple issues though:

1. The changes made for UUID types breaks the `crystal tasks.cr db.reset` task because for whatever reason running `shards` doesn't install the latest version of `LuckyMigrator`.
```
in db/migrations/20180628193054_create_product.cr:3: no argument named 'primary_key_type'

    create :products, primary_key_type: :uuid
```

2. I had to make the `where` clause accept `Nil` to allow `validates_uniqueness_of` to work since it can potentially send a `nil` value.
```
private def validate_uniqueness_of(
    field : LuckyRecord::Field,
    message : String = "is already taken"
  )
    field.value.try do |value|
      if build_validation_query(field.name, field.value).first? # field.value might be nil
        field.add_error message
      end
    end
  end
```
This wasn't a problem before because nil would be converted into an empty string. Do you think allowing `Nil` is okay or should I deal with it differently?
