### PR TITLE
Fix time parsing

### DIFF
--- a/spec/type_extensions/time_spec.cr
+++ b/spec/type_extensions/time_spec.cr
@@ -1,0 +1,29 @@
+require "../../spec_helper"
+
+describe "Time column type" do
+  describe ".parse" do
+    it "casts an ISO8601 String successfully" do
+      time = Time.new.to_s("%FT%X%z")
+
+      result = Time::Lucky.parse(time)
+
+      result.should be_a(LuckyRecord::Type::SuccessfulCast(Time))
+    end
+
+    it "casts a Time successfully" do
+      time = Time.new
+
+      result = Time::Lucky.parse(time)
+
+      result.value.should eq(time)
+    end
+
+    it "can't cast an invalid value" do
+      time = Time.new
+
+      result = Time::Lucky.parse("oh no")
+
+      result.should be_a(LuckyRecord::Type::FailedCast)
+    end
+  end
+end

--- a/src/lucky_record/charms/time_extensions.cr
+++ b/src/lucky_record/charms/time_extensions.cr
@@ -8,7 +8,7 @@ struct Time
     end
 
     def self.parse(value : String)
-      SuccessfulCast(Time).new Time.parse(value, "%FT%X%z").to_utc
+      SuccessfulCast(Time).new Time.parse_iso8601(value).to_utc
     rescue Time::Format::Error
       FailedCast.new
     end


### PR DESCRIPTION
Crystal recently updated how it parses dates, but they also added a 
nice 
convenience method that we can use to parse strings since we expect 
them 
to be UTC.