### PR TITLE
Improve association joins in queries.

### DIFF
--- a/src/lucky_record/associations.cr
+++ b/src/lucky_record/associations.cr
@@ -69,7 +69,7 @@ module LuckyRecord::Associations
 
     association table_name: :{{ model.resolve.constant(:TABLE_NAME).id }},
                 type: {{ model }},
-                foreign_key: :id,
+                foreign_key: :{{ foreign_key }},
                 relationship_type: :belongs_to
 
     define_belongs_to_private_assoc_getter({{ assoc_name }}, {{ model }}, {{ foreign_key }}, {{ nilable }})


### PR DESCRIPTION
Feels like I went down the rabbit hole... But I think I emerged with an actual solution to a couple of problems.

But let me start at the beginning. I am still wrestling with a `has_many ..., through: ...` relationship. Let's assume the example from the guides:

```crystal
class Tagging < BaseModel
  table :taggings do
    belongs_to tag : Tag
    belongs_to post : Post
  end
end

class Tag < BaseModel
  table :tags do
    column name : String
    has_many taggings : Tagging
    has_many posts : Post, through: :taggings
  end
end

class Post < BaseModel
  table :posts do
    column title : String
    has_many taggings : Tagging
    has_many tags : Tag, through: :taggings
  end
end
```

I wanted to create a custom scope in my `PostQuery` class that joins the tags. LuckyRecord automatically generates a `join_tags` methods, but that did not consider for the join table (taggings in this case).

I found a workaround in my app, but thought this should be reasonably simple to fix in LuckyRecord directly, so I started working on this.

The cleanest solution I could think of, was trying to make use of the existing `has_many taggings` relationship and from there use the existing `belongs_to tag` relationship defined in the Taggings model.

As it turned out, the generated `join_` method for `belongs_to` did not work either. It used the `id` column on both sides of the equation in the join condition.

So I set out to fix this as well. But when I finally managed to get it working, I still was not satisfied. All the time I spent on the `inner_join_*` method, the `left_join_*` method below stared me right in the face. And it was clearly making an INNER instead of a LEFT JOIN.

I then decided to try to fix this as well and add some specs for it.

Now, I do have a solution for all three problems that passes all specs on my machine. It is probably less readable than what was there before, but should handle all cases correctly (or at least better than before).

Let me know what you think. And keep up the good work!