### PR TITLE
Fix comparisons to `nil` in queries & make such queries explicit

### DIFF
--- a/spec/criteria_spec.cr
+++ b/spec/criteria_spec.cr
@@ -1,10 +1,11 @@
 require "./spec_helper"
 
 private class QueryMe < LuckyRecord::Model
-  COLUMNS = "users.id, users.created_at, users.updated_at, users.age"
+  COLUMNS = "users.id, users.created_at, users.updated_at, users.age, users.nickname"
 
   table users do
     column age : Int32
+    column nickname : String?
   end
 end
 
@@ -15,9 +16,29 @@ describe LuckyRecord::Criteria do
     end
   end
 
+  describe "is?" do
+    it "uses =" do
+      age.is?(30).to_sql.should eq ["SELECT #{QueryMe::COLUMNS} FROM users WHERE users.age = $1", "30"]
+    end
+
+    it "uses 'IS NULL' for comparisons to nil" do
+      nickname.is?(nil).to_sql.should eq ["SELECT #{QueryMe::COLUMNS} FROM users WHERE users.nickname IS NULL"]
+    end
+  end
+
   describe "is_not" do
     it "uses !=" do
       age.is_not(30).to_sql.should eq ["SELECT #{QueryMe::COLUMNS} FROM users WHERE users.age != $1", "30"]
+    end
+  end
+
+  describe "is_not?" do
+    it "uses !=" do
+      age.is_not?(30).to_sql.should eq ["SELECT #{QueryMe::COLUMNS} FROM users WHERE users.age != $1", "30"]
+    end
+
+    it "uses 'IS NOT NULL' for comparisons to nil" do
+      nickname.is_not?(nil).to_sql.should eq ["SELECT #{QueryMe::COLUMNS} FROM users WHERE users.nickname IS NOT NULL"]
     end
   end
 
@@ -66,4 +87,8 @@ end
 
 private def age
   QueryMe::BaseQuery.new.age
+end
+
+private def nickname
+  QueryMe::BaseQuery.new.nickname
 end

--- a/spec/query_builder_spec.cr
+++ b/spec/query_builder_spec.cr
@@ -22,8 +22,9 @@ describe "LuckyRecord::QueryBuilder" do
     query = new_query
       .where(LuckyRecord::Where::Equal.new(:name, "Paul"))
       .where(LuckyRecord::Where::GreaterThan.new(:age, "20"))
+      .where(LuckyRecord::Where::Null.new(:nickname))
       .limit(1)
-    query.statement.should eq "SELECT * FROM users WHERE name = $1 AND age > $2 LIMIT 1"
+    query.statement.should eq "SELECT * FROM users WHERE name = $1 AND age > $2 AND nickname IS NULL LIMIT 1"
     query.args.should eq ["Paul", "20"]
   end
 

--- a/spec/where_spec.cr
+++ b/spec/where_spec.cr
@@ -1,13 +1,13 @@
 require "./spec_helper"
 
 macro should_negate(original_where, expected_negated_where)
-  {% if original_where.resolve < LuckyRecord::Where::ComparativeSqlClause %}
-    clause = {{original_where}}.new("column", "value").negated
-  {% else %}
+  {% if original_where.resolve < LuckyRecord::Where::NullSqlClause %}
     clause = {{original_where}}.new("column").negated
+  {% else %}
+    clause = {{original_where}}.new("column", "value").negated
   {% end %}
   clause.column.should eq "column"
-  {% if original_where.resolve < LuckyRecord::Where::ComparativeSqlClause %}
+  {% unless original_where.resolve < LuckyRecord::Where::NullSqlClause %}
     clause.value.should eq "value"
   {% end %}
   clause.should be_a({{expected_negated_where}})

--- a/spec/where_spec.cr
+++ b/spec/where_spec.cr
@@ -1,9 +1,15 @@
 require "./spec_helper"
 
 macro should_negate(original_where, expected_negated_where)
-  clause = {{original_where}}.new("column", "value").negated
+  {% if original_where.resolve < LuckyRecord::Where::ComparativeSqlClause %}
+    clause = {{original_where}}.new("column", "value").negated
+  {% else %}
+    clause = {{original_where}}.new("column").negated
+  {% end %}
   clause.column.should eq "column"
-  clause.value.should eq "value"
+  {% if original_where.resolve < LuckyRecord::Where::ComparativeSqlClause %}
+    clause.value.should eq "value"
+  {% end %}
   clause.should be_a({{expected_negated_where}})
 end
 
@@ -21,5 +27,6 @@ describe LuckyRecord::Where do
     should_negate(LuckyRecord::Where::NotIlike, LuckyRecord::Where::Ilike)
     should_negate(LuckyRecord::Where::In, LuckyRecord::Where::NotIn)
     should_negate(LuckyRecord::Where::NotIn, LuckyRecord::Where::In)
+    should_negate(LuckyRecord::Where::Null, LuckyRecord::Where::NotNull)
   end
 end

--- a/src/lucky_record/criteria.cr
+++ b/src/lucky_record/criteria.cr
@@ -17,7 +17,7 @@ class LuckyRecord::Criteria(T, V)
   end
 
   def is(_value : Nil)
-    {{ raise "Use `is?` instead of `is` if trying to check against nillable value." }}
+    {{ raise "Use `is?` instead of `is` if trying to check against a nilable value." }}
   end
 
   def is(value)
@@ -48,7 +48,7 @@ class LuckyRecord::Criteria(T, V)
   end
 
   def is_not(_value : Nil)
-    {{ raise "Use `is_not?` instead of `is_not` if trying to check against nillable value." }}
+    {{ raise "Use `is_not?` instead of `is_not` if trying to check against a nilable value." }}
   end
 
   def is_not?(value) : T

--- a/src/lucky_record/criteria.cr
+++ b/src/lucky_record/criteria.cr
@@ -16,7 +16,20 @@ class LuckyRecord::Criteria(T, V)
     rows
   end
 
+  def is(_value : Nil)
+    {{ raise "Use `is?` instead of `is` if trying to check against nillable value." }}
+  end
+
   def is(value)
+    is?(value)
+  end
+
+  def is?(_value : Nil)
+    add_clause(LuckyRecord::Where::Null.new(column))
+    rows
+  end
+
+  def is?(value)
     add_clause(LuckyRecord::Where::Equal.new(column, V::Lucky.to_db!(value)))
     rows
   end
@@ -32,6 +45,18 @@ class LuckyRecord::Criteria(T, V)
 
   def is_not(value) : T
     add_clause(LuckyRecord::Where::NotEqual.new(column, V::Lucky.to_db!(value)))
+  end
+
+  def is_not(_value : Nil)
+    {{ raise "Use `is_not?` instead of `is_not` if trying to check against nillable value." }}
+  end
+
+  def is_not?(value) : T
+    add_clause(LuckyRecord::Where::NotEqual.new(column, V::Lucky.to_db!(value)))
+  end
+
+  def is_not?(_value : Nil) : T
+    add_clause(LuckyRecord::Where::NotNull.new(column))
   end
 
   def gt(value) : T

--- a/src/lucky_record/query_builder.cr
+++ b/src/lucky_record/query_builder.cr
@@ -211,10 +211,10 @@ class LuckyRecord::QueryBuilder
   private def joined_wheres_queries
     if @wheres.any? || @raw_wheres.any?
       statements = @wheres.map do |sql_clause|
-        if sql_clause.is_a?(LuckyRecord::Where::ComparativeSqlClause)
-          sql_clause.prepare(next_prepared_statement_placeholder)
-        else
+        if sql_clause.is_a?(LuckyRecord::Where::NullSqlClause)
           sql_clause.prepare
+        else
+          sql_clause.prepare(next_prepared_statement_placeholder)
         end
       end
       statements += @raw_wheres.map(&.to_sql)
@@ -225,7 +225,7 @@ class LuckyRecord::QueryBuilder
 
   private def prepared_statement_values
     @wheres.compact_map do |sql_clause|
-      sql_clause.value if sql_clause.is_a?(LuckyRecord::Where::ComparativeSqlClause)
+      sql_clause.value unless sql_clause.is_a?(LuckyRecord::Where::NullSqlClause)
     end
   end
 

--- a/src/lucky_record/query_builder.cr
+++ b/src/lucky_record/query_builder.cr
@@ -210,7 +210,13 @@ class LuckyRecord::QueryBuilder
 
   private def joined_wheres_queries
     if @wheres.any? || @raw_wheres.any?
-      statements = @wheres.map(&.prepare(next_prepared_statement_placeholder))
+      statements = @wheres.map do |sql_clause|
+        if sql_clause.is_a?(LuckyRecord::Where::ComparativeSqlClause)
+          sql_clause.prepare(next_prepared_statement_placeholder)
+        else
+          sql_clause.prepare
+        end
+      end
       statements += @raw_wheres.map(&.to_sql)
 
       "WHERE " + statements.join(" AND ")
@@ -218,7 +224,9 @@ class LuckyRecord::QueryBuilder
   end
 
   private def prepared_statement_values
-    @wheres.map(&.value)
+    @wheres.compact_map do |sql_clause|
+      sql_clause.value if sql_clause.is_a?(LuckyRecord::Where::ComparativeSqlClause)
+    end
   end
 
   private def next_prepared_statement_placeholder

--- a/src/lucky_record/where.cr
+++ b/src/lucky_record/where.cr
@@ -25,7 +25,6 @@ module LuckyRecord::Where
     end
   end
 
-
   class Null < NullSqlClause
     def operator
       "IS"

--- a/src/lucky_record/where.cr
+++ b/src/lucky_record/where.cr
@@ -1,19 +1,53 @@
 module LuckyRecord::Where
   abstract class SqlClause
-    getter :column, :value
+    getter :column
+
+    def initialize(@column : Symbol | String)
+    end
+
+    abstract def operator : String
+    abstract def negated : SqlClause
+
+    def prepare
+      "#{column} #{operator}"
+    end
+  end
+
+  abstract class ComparativeSqlClause < SqlClause
+    getter :value
 
     def initialize(@column : Symbol | String, @value : String | Array(String) | Array(Int32))
     end
 
     abstract def operator : String
-    abstract def negated : SqlClause
+    abstract def negated : ComparativeSqlClause
 
     def prepare(prepared_statement_placeholder : String)
       "#{column} #{operator} #{prepared_statement_placeholder}"
     end
   end
 
-  class Equal < SqlClause
+  class Null < SqlClause
+    def operator
+      "IS NULL"
+    end
+
+    def negated : NotNull
+      NotNull.new(@column)
+    end
+  end
+
+  class NotNull < SqlClause
+    def operator
+      "IS NOT NULL"
+    end
+
+    def negated : Null
+      Null.new(@column)
+    end
+  end
+
+  class Equal < ComparativeSqlClause
     def operator
       "="
     end
@@ -23,7 +57,7 @@ module LuckyRecord::Where
     end
   end
 
-  class NotEqual < SqlClause
+  class NotEqual < ComparativeSqlClause
     def operator
       "!="
     end
@@ -33,7 +67,7 @@ module LuckyRecord::Where
     end
   end
 
-  class GreaterThan < SqlClause
+  class GreaterThan < ComparativeSqlClause
     def operator
       ">"
     end
@@ -43,7 +77,7 @@ module LuckyRecord::Where
     end
   end
 
-  class GreaterThanOrEqualTo < SqlClause
+  class GreaterThanOrEqualTo < ComparativeSqlClause
     def operator
       ">="
     end
@@ -53,7 +87,7 @@ module LuckyRecord::Where
     end
   end
 
-  class LessThan < SqlClause
+  class LessThan < ComparativeSqlClause
     def operator
       "<"
     end
@@ -63,7 +97,7 @@ module LuckyRecord::Where
     end
   end
 
-  class LessThanOrEqualTo < SqlClause
+  class LessThanOrEqualTo < ComparativeSqlClause
     def operator
       "<="
     end
@@ -73,7 +107,7 @@ module LuckyRecord::Where
     end
   end
 
-  class Like < SqlClause
+  class Like < ComparativeSqlClause
     def operator
       "LIKE"
     end
@@ -83,7 +117,7 @@ module LuckyRecord::Where
     end
   end
 
-  class Ilike < SqlClause
+  class Ilike < ComparativeSqlClause
     def operator
       "ILIKE"
     end
@@ -93,7 +127,7 @@ module LuckyRecord::Where
     end
   end
 
-  class NotLike < SqlClause
+  class NotLike < ComparativeSqlClause
     def operator
       "NOT LIKE"
     end
@@ -103,7 +137,7 @@ module LuckyRecord::Where
     end
   end
 
-  class NotIlike < SqlClause
+  class NotIlike < ComparativeSqlClause
     def operator
       "NOT ILIKE"
     end
@@ -113,7 +147,7 @@ module LuckyRecord::Where
     end
   end
 
-  class In < SqlClause
+  class In < ComparativeSqlClause
     def operator
       "= ANY"
     end
@@ -127,7 +161,7 @@ module LuckyRecord::Where
     end
   end
 
-  class NotIn < SqlClause
+  class NotIn < ComparativeSqlClause
     def operator
       "!= ALL"
     end

--- a/src/lucky_record/where.cr
+++ b/src/lucky_record/where.cr
@@ -1,35 +1,34 @@
 module LuckyRecord::Where
   abstract class SqlClause
     getter :column
-
-    def initialize(@column : Symbol | String)
-    end
-
-    abstract def operator : String
-    abstract def negated : SqlClause
-
-    def prepare
-      "#{column} #{operator}"
-    end
-  end
-
-  abstract class ComparativeSqlClause < SqlClause
     getter :value
 
     def initialize(@column : Symbol | String, @value : String | Array(String) | Array(Int32))
     end
 
     abstract def operator : String
-    abstract def negated : ComparativeSqlClause
+    abstract def negated : SqlClause
 
     def prepare(prepared_statement_placeholder : String)
       "#{column} #{operator} #{prepared_statement_placeholder}"
     end
   end
 
-  class Null < SqlClause
+  abstract class NullSqlClause < SqlClause
+    @value = "NULL"
+
+    def initialize(@column : Symbol | String)
+    end
+
+    def prepare
+      "#{column} #{operator} #{@value}"
+    end
+  end
+
+
+  class Null < NullSqlClause
     def operator
-      "IS NULL"
+      "IS"
     end
 
     def negated : NotNull
@@ -37,9 +36,9 @@ module LuckyRecord::Where
     end
   end
 
-  class NotNull < SqlClause
+  class NotNull < NullSqlClause
     def operator
-      "IS NOT NULL"
+      "IS NOT"
     end
 
     def negated : Null
@@ -47,7 +46,7 @@ module LuckyRecord::Where
     end
   end
 
-  class Equal < ComparativeSqlClause
+  class Equal < SqlClause
     def operator
       "="
     end
@@ -57,7 +56,7 @@ module LuckyRecord::Where
     end
   end
 
-  class NotEqual < ComparativeSqlClause
+  class NotEqual < SqlClause
     def operator
       "!="
     end
@@ -67,7 +66,7 @@ module LuckyRecord::Where
     end
   end
 
-  class GreaterThan < ComparativeSqlClause
+  class GreaterThan < SqlClause
     def operator
       ">"
     end
@@ -77,7 +76,7 @@ module LuckyRecord::Where
     end
   end
 
-  class GreaterThanOrEqualTo < ComparativeSqlClause
+  class GreaterThanOrEqualTo < SqlClause
     def operator
       ">="
     end
@@ -87,7 +86,7 @@ module LuckyRecord::Where
     end
   end
 
-  class LessThan < ComparativeSqlClause
+  class LessThan < SqlClause
     def operator
       "<"
     end
@@ -97,7 +96,7 @@ module LuckyRecord::Where
     end
   end
 
-  class LessThanOrEqualTo < ComparativeSqlClause
+  class LessThanOrEqualTo < SqlClause
     def operator
       "<="
     end
@@ -107,7 +106,7 @@ module LuckyRecord::Where
     end
   end
 
-  class Like < ComparativeSqlClause
+  class Like < SqlClause
     def operator
       "LIKE"
     end
@@ -117,7 +116,7 @@ module LuckyRecord::Where
     end
   end
 
-  class Ilike < ComparativeSqlClause
+  class Ilike < SqlClause
     def operator
       "ILIKE"
     end
@@ -127,7 +126,7 @@ module LuckyRecord::Where
     end
   end
 
-  class NotLike < ComparativeSqlClause
+  class NotLike < SqlClause
     def operator
       "NOT LIKE"
     end
@@ -137,7 +136,7 @@ module LuckyRecord::Where
     end
   end
 
-  class NotIlike < ComparativeSqlClause
+  class NotIlike < SqlClause
     def operator
       "NOT ILIKE"
     end
@@ -147,7 +146,7 @@ module LuckyRecord::Where
     end
   end
 
-  class In < ComparativeSqlClause
+  class In < SqlClause
     def operator
       "= ANY"
     end
@@ -161,7 +160,7 @@ module LuckyRecord::Where
     end
   end
 
-  class NotIn < ComparativeSqlClause
+  class NotIn < SqlClause
     def operator
       "!= ALL"
     end


### PR DESCRIPTION
Fixes #123

Not totally happy with `is?`/`is_not?` as method names as it overloads a third additional meaning for `?`-suffixed methods (the first two being (1) methods which can return `nil` and (2) methods which always return booleans) so I'm open to ideas there.