### PR TITLE
Fix multiple belongs_to of the same class

### DIFF
--- a/src/lucky_record/associations.cr
+++ b/src/lucky_record/associations.cr
@@ -131,10 +131,10 @@ module LuckyRecord::Associations
   private macro define_belongs_to_base_query(assoc_name, model, foreign_key)
     class BaseQuery < LuckyRecord::Query
       def preload_{{ assoc_name }}
-        preload({{ model }}::BaseQuery.new)
+        preload_{{ assoc_name }}({{ model }}::BaseQuery.new)
       end
 
-      def preload(preload_query : {{ model }}::BaseQuery)
+      def preload_{{ assoc_name }}(preload_query : {{ model }}::BaseQuery)
         add_preload do |records|
           ids = [] of {{ model.resolve.constant(:PRIMARY_KEY_TYPE_CLASS) }}
           records.each do |record|


### PR DESCRIPTION
**Note**: This could use a test. I looked into it but there were no `belongs_to` tests currently and it's late and I didn't feel like tackling that now. Happy to soon if you think it needs it.

---

If a record has multiple belongs to that references the same class, it
would error saying `<assoc_name> for <ClassName> must be preloaded with
'preload_<assoc_name>' (LuckyRecord::LazyLoadError)`, even if the user
has preloaded it.

For example, with this Follow model:

```crystal
class Follow < BaseModel
  table :follows do
    belongs_to from : User
    belongs_to to : User
  end
end
```

When queried like so:

```crystal
FollowQuery.new.preload_from
```

would not work and throw the above error.

This is because when a belongs_to is defined, the method `preload`
method is redefined. Since it uses the same class for the method, it
essentially erases the previous method definitions.

```crystal
belongs_to from : User
belongs_to to : User
```

is turned into

```crystal
# define the from association
def preload(preload_query : User::BaseQuery)

# later, define the to association
def preload(preload_query : User::BaseQuery)
```

The fix was to append the association name to the preload method:

```crystal
def preload_from(preload_query : User::BaseQuery)

# later
def preload_to(preload_query : User::BaseQuery)
```

This also has the advantage of clarifying the API.

```crystal
# Current way
query.preload(UserQuery.new) # Is it preloading a "user", or an
"author"? Not clear

# New way
query.preload_author(UserQuery.new) # Clear what association is
preloaded
```

fixes #290